### PR TITLE
feat: framework guides + validator locale expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Updated roadmap and positioning docs (`TODO.md`, `POSITIONING_CHECKLIST.md`, `NPM_POSITIONING.md`) for community-facing execution.
 - Added docs cookbook navigation, client-side recipe search, and a new object-utilities recipe page.
 - Added quick-search and related-recipe sections across each docs problem page with no-JS cookbook fallback links.
+- Added framework integration guides (Next.js, Express, NestJS) and a validator locale matrix page.
+- Expanded validator locale support for phone/postal checks (US, CO, MX, ES, AR, CL, PE, BR).
 
 ## 1.3.1 - 2026-02-07
 

--- a/TODO.md
+++ b/TODO.md
@@ -25,13 +25,13 @@
 - [x] Issue templates for bug reports and feature requests.
 - [x] Add docs website search and cookbook navigation.
 - [ ] Publish "When to use this package" section across npm package pages (README sync check).
-- [ ] Add locale packs for validators (more countries and postal formats).
+- [x] Add locale packs for validators (phone + postal coverage for US, CO, MX, ES, AR, CL, PE, BR).
 - [x] Add object utilities package (`solvejs-objects`) based on community demand.
 - [x] Publish and announce `v1.2.0` across npm and GitHub release notes.
 
 ## Next Iteration (Community-Driven)
 
-- [ ] Add framework integration guides: Next.js, Express, NestJS.
+- [x] Add framework integration guides: Next.js, Express, NestJS.
 - [ ] Add validator locale expansion matrix (`phone`, `postalCode`, `addressDirection`) by country.
 - [ ] Add recipe-style docs pages with copy/paste snippets for top intents.
 - [ ] Add monthly community vote issue for next utility priorities.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,3 +19,10 @@ Static documentation for GitHub Pages with a searchable cookbook UX.
 - `string-format`
 - `regex-patterns`
 - `object-utils`
+
+## Integration Guides
+
+- `guides/nextjs-integration`
+- `guides/express-integration`
+- `guides/nest-integration`
+- `guides/validator-locale-matrix`

--- a/docs/app.js
+++ b/docs/app.js
@@ -52,6 +52,42 @@ const TOPICS = [
     tags: ["object", "deep merge", "nested path"],
     packages: ["@jdsalasc/solvejs-objects"],
     level: "Intermediate"
+  },
+  {
+    id: "nextjs-integration",
+    title: "Integrate SolveJS in Next.js",
+    description: "Use validators and parsers in route handlers and server actions.",
+    path: "guides/nextjs-integration.html",
+    tags: ["nextjs", "integration", "api"],
+    packages: ["@jdsalasc/solvejs-validators", "@jdsalasc/solvejs-numbers"],
+    level: "Intermediate"
+  },
+  {
+    id: "express-integration",
+    title: "Integrate SolveJS in Express",
+    description: "Add reusable validation middleware with structured result codes.",
+    path: "guides/express-integration.html",
+    tags: ["express", "integration", "middleware"],
+    packages: ["@jdsalasc/solvejs-validators"],
+    level: "Intermediate"
+  },
+  {
+    id: "nest-integration",
+    title: "Integrate SolveJS in NestJS",
+    description: "Use utility validators inside services and domain logic.",
+    path: "guides/nest-integration.html",
+    tags: ["nestjs", "integration", "service"],
+    packages: ["@jdsalasc/solvejs-validators"],
+    level: "Intermediate"
+  },
+  {
+    id: "validator-locale-matrix",
+    title: "Validator Locale Matrix",
+    description: "See current country coverage for phone and postal validation.",
+    path: "guides/validator-locale-matrix.html",
+    tags: ["validators", "locale", "postal", "phone"],
+    packages: ["@jdsalasc/solvejs-validators"],
+    level: "Reference"
   }
 ];
 

--- a/docs/guides/express-integration.html
+++ b/docs/guides/express-integration.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Integrate SolveJS utilities in Express middleware and controllers." />
+  <title>Express Integration Guide | SolveJS</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body data-root="..">
+  <main class="page">
+    <section class="hero">
+      <h1>Integrate SolveJS in Express</h1>
+      <p>Reuse the same validation and utility rules in middleware and handlers.</p>
+    </section>
+
+    <section class="layout">
+      <aside class="panel">
+        <h2>Cookbook Navigation</h2>
+        <nav data-cookbook-nav aria-label="Cookbook pages"></nav>
+      </aside>
+
+      <section class="panel">
+        <h2>Middleware Example</h2>
+        <pre><code>import { validateCellphoneNumber, validateHttpUrl } from "@jdsalasc/solvejs-validators";
+
+export function validateSignup(req, res, next) {
+  const phone = validateCellphoneNumber(String(req.body.phone ?? ""), { country: "CO" });
+  const website = validateHttpUrl(String(req.body.website ?? ""));
+
+  if (!phone.ok || !website.ok) {
+    return res.status(400).json({ ok: false, phone, website });
+  }
+
+  return next();
+}</code></pre>
+      </section>
+    </section>
+
+    <p class="back-link"><a class="inline-link" href="../index.html">Back to docs home</a></p>
+  </main>
+
+  <script src="../app.js"></script>
+</body>
+</html>

--- a/docs/guides/nest-integration.html
+++ b/docs/guides/nest-integration.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Integrate SolveJS utilities in NestJS DTO validation and services." />
+  <title>NestJS Integration Guide | SolveJS</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body data-root="..">
+  <main class="page">
+    <section class="hero">
+      <h1>Integrate SolveJS in NestJS</h1>
+      <p>Apply SolveJS rules inside service methods to keep business validation centralized.</p>
+    </section>
+
+    <section class="layout">
+      <aside class="panel">
+        <h2>Cookbook Navigation</h2>
+        <nav data-cookbook-nav aria-label="Cookbook pages"></nav>
+      </aside>
+
+      <section class="panel">
+        <h2>Service Example</h2>
+        <pre><code>import { Injectable, BadRequestException } from "@nestjs/common";
+import { validateUsername, validatePostalCode } from "@jdsalasc/solvejs-validators";
+
+@Injectable()
+export class UsersService {
+  create(input: { username: string; postalCode: string }) {
+    const username = validateUsername(input.username);
+    const postal = validatePostalCode(input.postalCode, { country: "US" });
+
+    if (!username.ok || !postal.ok) {
+      throw new BadRequestException({ username, postal });
+    }
+
+    return { ok: true };
+  }
+}</code></pre>
+      </section>
+    </section>
+
+    <p class="back-link"><a class="inline-link" href="../index.html">Back to docs home</a></p>
+  </main>
+
+  <script src="../app.js"></script>
+</body>
+</html>

--- a/docs/guides/nextjs-integration.html
+++ b/docs/guides/nextjs-integration.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Integrate SolveJS utilities in Next.js apps with server and client examples." />
+  <title>Next.js Integration Guide | SolveJS</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body data-root="..">
+  <main class="page">
+    <section class="hero">
+      <h1>Integrate SolveJS in Next.js</h1>
+      <p>Use focused SolveJS packages in route handlers and UI layers without adding runtime dependencies.</p>
+    </section>
+
+    <section class="layout">
+      <aside class="panel">
+        <h2>Cookbook Navigation</h2>
+        <nav data-cookbook-nav aria-label="Cookbook pages"></nav>
+      </aside>
+
+      <section class="panel">
+        <h2>Route Handler Example</h2>
+        <pre><code>import { validateEmail } from "@jdsalasc/solvejs-validators";
+import { toNumber } from "@jdsalasc/solvejs-numbers";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const emailResult = validateEmail(body.email ?? "");
+  const amount = toNumber(String(body.amount ?? ""));
+
+  if (!emailResult.ok || amount === null) {
+    return Response.json({ ok: false, emailResult, amount }, { status: 400 });
+  }
+
+  return Response.json({ ok: true });
+}</code></pre>
+      </section>
+    </section>
+
+    <p class="back-link"><a class="inline-link" href="../index.html">Back to docs home</a></p>
+  </main>
+
+  <script src="../app.js"></script>
+</body>
+</html>

--- a/docs/guides/validator-locale-matrix.html
+++ b/docs/guides/validator-locale-matrix.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Current locale matrix for SolveJS phone and postal validation coverage." />
+  <title>Validator Locale Matrix | SolveJS</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body data-root="..">
+  <main class="page">
+    <section class="hero">
+      <h1>Validator Locale Matrix</h1>
+      <p>Current country coverage for <code>validateCellphoneNumber</code> and <code>validatePostalCode</code>.</p>
+    </section>
+
+    <section class="layout">
+      <aside class="panel">
+        <h2>Cookbook Navigation</h2>
+        <nav data-cookbook-nav aria-label="Cookbook pages"></nav>
+      </aside>
+
+      <section class="panel">
+        <h2>Country Coverage</h2>
+        <pre><code>US: phone + postal
+CO: phone + postal
+MX: phone + postal
+ES: phone + postal
+AR: phone + postal
+CL: phone + postal
+PE: phone + postal
+BR: phone + postal
+ANY: phone-only preset</code></pre>
+        <p class="caption">Postal validation is country-aware via <code>validatePostalCode(value, { country })</code>. Default country is <code>US</code>.</p>
+      </section>
+    </section>
+
+    <p class="back-link"><a class="inline-link" href="../index.html">Back to docs home</a></p>
+  </main>
+
+  <script src="../app.js"></script>
+</body>
+</html>

--- a/docs/guides/validator-locale-matrix.md
+++ b/docs/guides/validator-locale-matrix.md
@@ -1,0 +1,15 @@
+# Validator Locale Matrix
+
+Current country coverage for `validateCellphoneNumber` and `validatePostalCode`.
+
+- `US`: phone + postal
+- `CO`: phone + postal
+- `MX`: phone + postal
+- `ES`: phone + postal
+- `AR`: phone + postal
+- `CL`: phone + postal
+- `PE`: phone + postal
+- `BR`: phone + postal
+- `ANY`: phone-only preset
+
+`validatePostalCode` is country-aware with `validatePostalCode(value, { country })`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,6 +28,10 @@
             <li><a class="cookbook-link" href="./problems/string-format.html">Normalize and Sanitize Strings</a></li>
             <li><a class="cookbook-link" href="./problems/regex-patterns.html">Use Common Regex Patterns</a></li>
             <li><a class="cookbook-link" href="./problems/object-utils.html">Shape and Merge Objects</a></li>
+            <li><a class="cookbook-link" href="./guides/nextjs-integration.html">Integrate SolveJS in Next.js</a></li>
+            <li><a class="cookbook-link" href="./guides/express-integration.html">Integrate SolveJS in Express</a></li>
+            <li><a class="cookbook-link" href="./guides/nest-integration.html">Integrate SolveJS in NestJS</a></li>
+            <li><a class="cookbook-link" href="./guides/validator-locale-matrix.html">Validator Locale Matrix</a></li>
           </ul>
         </noscript>
       </aside>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -21,4 +21,16 @@
   <url>
     <loc>https://jdsalasca.github.io/solvejs/problems/object-utils.html</loc>
   </url>
+  <url>
+    <loc>https://jdsalasca.github.io/solvejs/guides/nextjs-integration.html</loc>
+  </url>
+  <url>
+    <loc>https://jdsalasca.github.io/solvejs/guides/express-integration.html</loc>
+  </url>
+  <url>
+    <loc>https://jdsalasca.github.io/solvejs/guides/nest-integration.html</loc>
+  </url>
+  <url>
+    <loc>https://jdsalasca.github.io/solvejs/guides/validator-locale-matrix.html</loc>
+  </url>
 </urlset>

--- a/packages/solvejs-validators/README.md
+++ b/packages/solvejs-validators/README.md
@@ -6,7 +6,7 @@ Zero-dependency validators for JavaScript and TypeScript forms and API payloads.
 
 - Structured validators returning `{ ok, code, message }`
 - `validateCellphoneNumber`, `validateEmail`, `validateHttpUrl`
-- `validateName`, `validateUsername`, `validateAddressLine`, `validatePostalCode`
+- `validateName`, `validateUsername`, `validateAddressLine`, `validatePostalCode` (country-aware)
 - `validateStrongPassword`, `validateCreditCardNumber`
 - `validateUuidV4`, `validateIpv4`, `validateIsoDateString`
 - Boolean wrappers (`isX`) for quick checks
@@ -28,4 +28,7 @@ import { validateCellphoneNumber, validateUuidV4 } from "@jdsalasc/solvejs-valid
 
 validateCellphoneNumber("+573001234567", { country: "CO" });
 validateUuidV4("550e8400-e29b-41d4-a716-446655440000");
+// Postal code examples by country:
+// validatePostalCode("110111", { country: "CO" });
+// validatePostalCode("28013", { country: "ES" });
 ```

--- a/packages/solvejs-validators/package.json
+++ b/packages/solvejs-validators/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdsalasc/solvejs-validators",
   "version": "1.3.0",
-  "description": "Zero-dependency JavaScript and TypeScript validators with result codes: cellphone, username, address, UUID v4, IPv4, and ISO date.",
+  "description": "Zero-dependency JavaScript and TypeScript validators with result codes: cellphone, username, address, country-aware postal code, UUID v4, IPv4, and ISO date.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -48,6 +48,7 @@
     "form validation",
     "api payload validation",
     "phone number validator",
+    "postal code validator",
     "username validator",
     "uuid v4 validator",
     "ipv4 validator",

--- a/packages/solvejs-validators/test/index.test.mjs
+++ b/packages/solvejs-validators/test/index.test.mjs
@@ -21,7 +21,8 @@ import {
   validateCellphoneNumber,
   validateCreditCardNumber,
   validateIsoDateString,
-  validateName
+  validateName,
+  validatePostalCode
 } from "../dist/esm/index.js";
 
 test("boolean validators keep compatibility", () => {
@@ -34,6 +35,8 @@ test("boolean validators keep compatibility", () => {
   assert.equal(isEmail("user@example.com"), true);
   assert.equal(isHttpUrl("https://solvejs.dev"), true);
   assert.equal(isPostalCode("12345-6789"), true);
+  assert.equal(isPostalCode("110111", { country: "CO" }), true);
+  assert.equal(isPostalCode("28013", { country: "ES" }), true);
   assert.equal(isAddressLine("221B Baker Street"), true);
   assert.equal(isStrongPassword("Aa123456!"), true);
   assert.equal(isCreditCardNumber("4111 1111 1111 1111"), true);
@@ -50,6 +53,12 @@ test("structured validators return codes and messages", () => {
   assert.equal(validateAddressDirection("west", { locale: "es" }).ok, false);
   assert.equal(validateName("A").code, "TOO_SHORT");
   assert.equal(validateAddressLine("A").code, "TOO_SHORT");
+  assert.equal(validatePostalCode("110111", { country: "CO" }).ok, true);
+  assert.equal(validatePostalCode("28013", { country: "ES" }).ok, true);
+  assert.equal(validatePostalCode("7500000", { country: "CL" }).ok, true);
+  assert.equal(validatePostalCode("110111", { country: "US" }).ok, false);
+  assert.equal(validateCellphoneNumber("+5491123456789", { country: "AR" }).ok, true);
+  assert.equal(validateCellphoneNumber("+5511912345678", { country: "BR" }).ok, true);
   assert.equal(validateCreditCardNumber("1234").code, "INVALID_FORMAT");
   assert.equal(validateIsoDateString("2026-02-30").code, "INVALID_FORMAT");
 });


### PR DESCRIPTION
## Summary
- add integration guides for Next.js, Express, and NestJS in docs
- add validator locale matrix reference page
- expand validator country support for cellphone and postal code checks (US, CO, MX, ES, AR, CL, PE, BR)
- update tests, roadmap, and changelog

## Validation
- npm test (all workspaces passing)
