### PR TITLE
docs: close validator address-direction matrix gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Added edge-case tests for string/list/regex packages to improve regression coverage.
 - Added automated package inventory generator (`npm run inventory`) producing Markdown + HTML docs snapshots.
 - Improved meta/readme adoption copy with clearer "why adopt" and docs entry points.
-- Added npm and Node compatibility badges across all package READMEs for stronger npm page trust signals.
+- Added npm and Node compatibility badges across all package READMEs for stronger npm page trust signals.`n- Expanded validator locale matrix docs to include address-direction locale coverage (`en`, `es`).
 
 ## 1.3.1 - 2026-02-07
 

--- a/TODO.md
+++ b/TODO.md
@@ -32,6 +32,6 @@
 ## Next Iteration (Community-Driven)
 
 - [x] Add framework integration guides: Next.js, Express, NestJS.
-- [ ] Add validator locale expansion matrix (`addressDirection`) by country.
+- [x] Add validator locale expansion matrix (`phone`, `postalCode`, `addressDirection`) by country/locale.
 - [x] Add recipe-style docs pages with copy/paste snippets for top intents.
 - [ ] Add monthly community vote issue for next utility priorities.

--- a/docs/guides/validator-locale-matrix.html
+++ b/docs/guides/validator-locale-matrix.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Current locale matrix for SolveJS phone and postal validation coverage." />
+  <meta name="description" content="Current locale matrix for SolveJS phone, postal code, and address direction validation coverage." />
   <title>Validator Locale Matrix | SolveJS</title>
   <link rel="stylesheet" href="../styles.css" />
 </head>
@@ -11,7 +11,7 @@
   <main class="page">
     <section class="hero">
       <h1>Validator Locale Matrix</h1>
-      <p>Current country coverage for <code>validateCellphoneNumber</code> and <code>validatePostalCode</code>.</p>
+      <p>Current coverage for <code>validateCellphoneNumber</code>, <code>validatePostalCode</code>, and <code>validateAddressDirection</code>.</p>
     </section>
 
     <section class="layout">
@@ -31,7 +31,10 @@ CL: phone + postal
 PE: phone + postal
 BR: phone + postal
 ANY: phone-only preset</code></pre>
-        <p class="caption">Postal validation is country-aware via <code>validatePostalCode(value, { country })</code>. Default country is <code>US</code>.</p>
+        <h2>Address Direction Locales</h2>
+        <pre><code>en: N, S, E, W, NE, NW, SE, SW + full words
+es: N, S, E, O, NE, NO, SE, SO + full words</code></pre>
+        <p class="caption">Postal validation is country-aware via <code>validatePostalCode(value, { country })</code>. Address direction is locale-aware via <code>validateAddressDirection(value, { locale })</code>.</p>
       </section>
     </section>
 

--- a/docs/guides/validator-locale-matrix.md
+++ b/docs/guides/validator-locale-matrix.md
@@ -1,6 +1,6 @@
 # Validator Locale Matrix
 
-Current country coverage for `validateCellphoneNumber` and `validatePostalCode`.
+Current coverage for `validateCellphoneNumber`, `validatePostalCode`, and `validateAddressDirection`.
 
 - `US`: phone + postal
 - `CO`: phone + postal
@@ -13,3 +13,8 @@ Current country coverage for `validateCellphoneNumber` and `validatePostalCode`.
 - `ANY`: phone-only preset
 
 `validatePostalCode` is country-aware with `validatePostalCode(value, { country })`.
+
+Address direction locales:
+
+- `en`: `N, S, E, W, NE, NW, SE, SW` + full words
+- `es`: `N, S, E, O, NE, NO, SE, SO` + full words


### PR DESCRIPTION
## Summary
- add address-direction locale coverage to validator matrix docs
- mark roadmap matrix item as completed
- update changelog note

## Validation
- npm test
