### PR TITLE
docs+release: package health report and publish workflow hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,19 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace:
+          - packages/solvejs-date
+          - packages/solvejs-string
+          - packages/solvejs-list
+          - packages/solvejs-regex
+          - packages/solvejs-constants
+          - packages/solvejs-numbers
+          - packages/solvejs-validators
+          - packages/solvejs-objects
+          - packages/solvejs
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,20 +40,47 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish packages
+      - name: Resolve package metadata
+        id: package
         run: |
-          npm publish --workspace packages/solvejs-date --access public
-          npm publish --workspace packages/solvejs-string --access public
-          npm publish --workspace packages/solvejs-list --access public
-          npm publish --workspace packages/solvejs-regex --access public
-          npm publish --workspace packages/solvejs-constants --access public
-          npm publish --workspace packages/solvejs-numbers --access public
-          npm publish --workspace packages/solvejs-validators --access public`n          npm publish --workspace packages/solvejs-objects --access public
-          npm publish --workspace packages/solvejs --access public
+          NAME=$(node -p "require('./${{ matrix.workspace }}/package.json').name")
+          VERSION=$(node -p "require('./${{ matrix.workspace }}/package.json').version")
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check npm token
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "NPM_TOKEN is missing. Configure repository secret NPM_TOKEN."
+            exit 1
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Check if version exists
+        id: registry
+        run: |
+          set +e
+          npm view "${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" version --json > /tmp/version.json 2>/tmp/npm-view.err
+          RESULT=$?
+          set -e
+          if [ $RESULT -eq 0 ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Version already exists on npm, skipping publish."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Version not found on npm, publishing."
+          fi
+
+      - name: Publish workspace
+        if: steps.registry.outputs.exists != 'true'
+        run: |
+          npm publish --workspace "${{ matrix.workspace }}" --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
+        if: matrix.workspace == 'packages/solvejs'
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Fixed `.github/workflows/release.yml` by removing broken publish command, adding per-workspace matrix publish, npm token validation, and idempotent version-exists checks.
+- Added package health report docs (`docs/guides/package-health-report.md` and `.html`) with package status, issues, weak points, and prioritized actions.
+- Updated docs navigation to include the new package health report.
+- Regenerated package inventory docs for current `1.4.0` package versions.
+- Updated roadmap (`TODO.md`) with `v1.5.0` candidate priorities.
+- Expanded `NPM_POSITIONING.md` with canonical npm description copy for each package.
+
 ## 1.4.0 - 2026-02-07
 
 - Added new package `@jdsalasc/solvejs-objects` with `pick`, `omit`, `hasOwn`, `get`, `set`, and `deepMerge`.

--- a/NPM_POSITIONING.md
+++ b/NPM_POSITIONING.md
@@ -40,6 +40,29 @@ Use this file to keep npm package messaging, discoverability terms, and README i
   - Position: object shaping and nested path helpers.
   - Search intents: `pick object keys`, `deep merge objects`, `set nested value`.
 
+## npm Description Copy (English)
+
+Use these as the canonical package `description` strings in `package.json`.
+
+- `@jdsalasc/solvejs`:
+  - `Practical zero-dependency JS/TS utility suite for dates, strings, lists, regex, constants, numbers, validators, and objects.`
+- `@jdsalasc/solvejs-date`:
+  - `Production-ready JS/TS date utilities: strict parsing, UTC-safe formatting, unix timestamp parsing, and date math.`
+- `@jdsalasc/solvejs-string`:
+  - `Production-ready JS/TS string utilities: slugify, casing, sanitize/strip HTML, masking, and truncation.`
+- `@jdsalasc/solvejs-list`:
+  - `Production-ready JS/TS list utilities: uniqueBy, groupBy, keyBy, partition, intersection, difference, and sorting.`
+- `@jdsalasc/solvejs-regex`:
+  - `Production-ready JS/TS regex utilities with built-in patterns (uuidV4, ipv4, isoDate) and safe escaping helpers.`
+- `@jdsalasc/solvejs-constants`:
+  - `Production-ready JS/TS constants for time, file sizes, HTTP methods/headers, and boolean parsing.`
+- `@jdsalasc/solvejs-numbers`:
+  - `Production-ready JS/TS number utilities: toNumber parsing, safeDivide, percentChange, clamp, roundTo, and currency formatting.`
+- `@jdsalasc/solvejs-validators`:
+  - `Production-ready JS/TS validators with structured result codes for forms/APIs: phone, username, postal, UUID, IPv4, and ISO date.`
+- `@jdsalasc/solvejs-objects`:
+  - `Production-ready JS/TS object utilities: pick, omit, hasOwn, get/set nested paths, and deepMerge.`
+
 ## Metadata Policy
 
 - Keep 8-14 high-intent keywords per package.

--- a/TODO.md
+++ b/TODO.md
@@ -36,3 +36,12 @@
 - [x] Add recipe-style docs pages with copy/paste snippets for top intents.
 - [x] Add monthly community vote issue for next utility priorities.
 - [x] Add comparison docs pages to support adoption decisions (`SolveJS vs ...`).
+
+## Next Iteration (v1.5.0 Candidate)
+
+- [ ] Resolve npm registry visibility/release consistency for `@jdsalasc/solvejs-objects`.
+- [ ] Harden release workflow with idempotent publish checks and explicit npm token validation.
+- [ ] Publish package health report (status, issues, weaknesses, improvements) for contributors.
+- [ ] Add deep edge-case tests for date timezone boundaries and object nested-path updates.
+- [ ] Expand validators locale/country coverage and document deprecation strategy for typo aliases.
+- [ ] Add lint baseline and CI enforcement across all workspaces.

--- a/docs/app.js
+++ b/docs/app.js
@@ -99,6 +99,15 @@ const TOPICS = [
     level: "Reference"
   },
   {
+    id: "package-health-report",
+    title: "Package Health Report",
+    description: "Review package status, known issues, weak points, and next improvements.",
+    path: "guides/package-health-report.html",
+    tags: ["inventory", "roadmap", "quality", "adoption"],
+    packages: ["@jdsalasc/solvejs"],
+    level: "Reference"
+  },
+  {
     id: "solvejs-vs-lodash",
     title: "SolveJS vs Lodash",
     description: "Compare scope, typing, and adoption fit for utility workflows.",

--- a/docs/guides/package-health-report.html
+++ b/docs/guides/package-health-report.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="SolveJS package health report with status, weak points, and roadmap actions." />
+  <title>Package Health Report | SolveJS</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body data-root="..">
+  <main class="page">
+    <section class="hero">
+      <h1>Package Health Report</h1>
+      <p>Updated on 2026-02-07. Status snapshot, known issues, and prioritized improvements.</p>
+    </section>
+
+    <section class="layout">
+      <aside class="panel">
+        <h2>Cookbook Navigation</h2>
+        <nav data-cookbook-nav aria-label="Cookbook pages"></nav>
+      </aside>
+      <section class="panel">
+        <h2>Package Status</h2>
+        <div style="overflow:auto">
+          <table style="width:100%; border-collapse: collapse;">
+            <thead>
+              <tr>
+                <th align="left">Package</th>
+                <th align="left">Practical utilities</th>
+                <th align="left">Current status</th>
+                <th align="left">Known issues</th>
+                <th align="left">Weak points</th>
+                <th align="left">Next improvements</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td><code>@jdsalasc/solvejs</code></td><td>Single import surface for all SolveJS domains.</td><td>1.4.0 in repo, tests passing locally.</td><td>Depends on <code>solvejs-objects@1.4.0</code> availability in npm.</td><td>No tree-shake guidance in README.</td><td>Add import-size examples and migration guide.</td></tr>
+              <tr><td><code>@jdsalasc/solvejs-date</code></td><td><code>parseDateStrict</code>, <code>parseIsoDate</code>, <code>parseUnixTimestamp</code>, <code>formatDate</code>.</td><td>1.4.0 stable with tests.</td><td>None critical identified.</td><td>Limited DST/timezone edge-case tests.</td><td>Add DST boundary tests and timezone recipes.</td></tr>
+              <tr><td><code>@jdsalasc/solvejs-string</code></td><td><code>slugify</code>, <code>stripHtml</code>, <code>truncate</code>, <code>mask</code>.</td><td>1.4.0 stable with tests.</td><td>None critical identified.</td><td>Limited Unicode/locale casing coverage.</td><td>Add Unicode normalization tests and notes.</td></tr>
+              <tr><td><code>@jdsalasc/solvejs-list</code></td><td><code>uniqueBy</code>, <code>groupBy</code>, <code>partition</code>, <code>sortBy</code>.</td><td>1.4.0 stable with tests.</td><td>None critical identified.</td><td>Large-array performance guidance is missing.</td><td>Add benchmark section for 10k/100k operations.</td></tr>
+              <tr><td><code>@jdsalasc/solvejs-regex</code></td><td><code>REGEX_PATTERNS</code>, <code>validateByName</code>, <code>escapeRegex</code>.</td><td>1.4.0 stable with tests.</td><td>None critical identified.</td><td>Pattern catalog can be wider for global use cases.</td><td>Add patterns plus false-positive examples.</td></tr>
+              <tr><td><code>@jdsalasc/solvejs-constants</code></td><td><code>TIME</code>, <code>FILE_SIZE_BYTES</code>, <code>HTTP_METHODS</code>, <code>COMMON_HTTP_HEADERS</code>.</td><td>1.4.0 stable with tests.</td><td>None critical identified.</td><td>Docs naming mismatch can confuse users.</td><td>Align docs with exported identifiers exactly.</td></tr>
+              <tr><td><code>@jdsalasc/solvejs-numbers</code></td><td><code>toNumber</code>, <code>safeDivide</code>, <code>percentChange</code>, <code>toCurrency</code>.</td><td>1.4.0 stable with tests.</td><td>None critical identified.</td><td>No precision caveats for finance-heavy flows.</td><td>Add precision guidance with examples.</td></tr>
+              <tr><td><code>@jdsalasc/solvejs-validators</code></td><td><code>validate*</code>/<code>is*</code> for phone, postal, username, UUID, IPv4, ISO date.</td><td>1.4.0 stable, locale matrix documented.</td><td>Legacy typo aliases kept for compatibility.</td><td>Country coverage still limited to current matrix.</td><td>Add deprecation notes and expand locale packs.</td></tr>
+              <tr><td><code>@jdsalasc/solvejs-objects</code></td><td><code>pick</code>, <code>omit</code>, <code>get</code>, <code>set</code>, <code>deepMerge</code>.</td><td>1.4.0 code complete and tested locally.</td><td>npm lookup returned <code>Not found</code> during audit.</td><td>Single test file; nested path cases can expand.</td><td>Fix npm visibility and add deeper tests.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </section>
+
+    <section class="panel">
+      <h2>Priority Order</h2>
+      <ol class="topic-list">
+        <li>Resolve npm visibility/publication state for <code>@jdsalasc/solvejs-objects</code>.</li>
+        <li>Increase edge-case tests in <code>date</code>, <code>string</code>, and <code>objects</code>.</li>
+        <li>Improve practical README/API examples for production constraints.</li>
+        <li>Add linting baseline and enforce in CI.</li>
+      </ol>
+    </section>
+
+    <p class="back-link"><a class="inline-link" href="../index.html">Back to docs home</a></p>
+  </main>
+  <script src="../app.js"></script>
+</body>
+</html>

--- a/docs/guides/package-health-report.md
+++ b/docs/guides/package-health-report.md
@@ -1,0 +1,30 @@
+# SolveJS Package Health Report
+
+Updated on 2026-02-07.
+
+This report lists each package, its practical utilities, current status, known issues, weak points, and next improvements.
+
+| Package | Practical utilities | Current status | Known issues | Weak points | Next improvements |
+|---|---|---|---|---|---|
+| `@jdsalasc/solvejs` | Single import surface for all SolveJS domains. | `1.4.0` in repo, tests passing locally. | Depends on `solvejs-objects@1.4.0` availability in npm. | No tree-shake guidance in README. | Add import-size examples and package-by-package migration guide. |
+| `@jdsalasc/solvejs-date` | `parseDateStrict`, `parseIsoDate`, `parseUnixTimestamp`, `formatDate`, `addDays`, `diffInDays`. | `1.4.0` stable with tests. | None critical identified. | Limited tests around DST and timezone edge cases. | Add DST boundary tests and timezone example recipes. |
+| `@jdsalasc/solvejs-string` | `slugify`, `stripHtml`, `truncate`, `mask`, casing helpers. | `1.4.0` stable with tests. | None critical identified. | Limited Unicode and locale-specific casing tests. | Add Unicode normalization test matrix and locale notes. |
+| `@jdsalasc/solvejs-list` | `uniqueBy`, `groupBy`, `partition`, `intersection`, `difference`, `sortBy`. | `1.4.0` stable with tests. | None critical identified. | Performance profile not documented for large arrays. | Add benchmark section for `10k`/`100k` list operations. |
+| `@jdsalasc/solvejs-regex` | `REGEX_PATTERNS`, `validateByName`, `validateWithPattern`, `escapeRegex`. | `1.4.0` stable with tests. | None critical identified. | Pattern coverage could be broader for global use cases. | Add additional patterns and false-positive examples. |
+| `@jdsalasc/solvejs-constants` | `TIME`, `FILE_SIZE_BYTES`, `HTTP_METHODS`, `COMMON_HTTP_HEADERS`, `parseBooleanString`. | `1.4.0` stable with tests. | None critical identified. | Naming overlap (`HTTP_HEADERS` in docs vs `COMMON_HTTP_HEADERS` in code) can confuse users. | Align docs wording exactly with exported names in every README page. |
+| `@jdsalasc/solvejs-numbers` | `toNumber`, `safeDivide`, `percentChange`, `toCurrency`, `roundTo`, `clamp`. | `1.4.0` stable with tests. | None critical identified. | No explicit precision guidance for financial calculations. | Add precision caveats and examples with controlled rounding. |
+| `@jdsalasc/solvejs-validators` | Structured validators (`validate*` + `is*`) for phone, postal, username, URL, UUID, IPv4, ISO date. | `1.4.0` stable with tests and locale matrix docs. | Contains legacy typo aliases (`isAddresDirection`, `isAddresDirrection`) kept for compatibility. | Country coverage still limited to current matrix. | Add deprecation note for typo aliases and expand country packs. |
+| `@jdsalasc/solvejs-objects` | `pick`, `omit`, `hasOwn`, `get`, `set`, `deepMerge`. | `1.4.0` code complete and tested locally. | npm registry visibility is inconsistent; package lookup returned `Not found` during audit. | Single test file; nested path edge-cases can be expanded. | Resolve npm publication/visibility and add deep nested path test suite. |
+
+## Cross-Package Gaps
+
+- Release workflow needed hardening for retries and partial publishes.
+- Some package READMEs can be more explicit about edge cases and constraints.
+- Lint command is currently placeholder text in all workspaces.
+
+## Priority Order
+
+1. Resolve npm visibility/publication state for `@jdsalasc/solvejs-objects`.
+2. Increase edge-case tests in `date`, `string`, and `objects`.
+3. Improve practical README/API examples focused on production constraints.
+4. Add linting baseline and enforce in CI.

--- a/docs/guides/package-inventory.html
+++ b/docs/guides/package-inventory.html
@@ -33,15 +33,15 @@
               </tr>
             </thead>
             <tbody>
-              <tr><td><code>@jdsalasc/solvejs</code></td><td>1.3.0</td><td>0</td><td>0</td><td>0</td><td>1</td></tr>
-<tr><td><code>@jdsalasc/solvejs-constants</code></td><td>1.3.0</td><td>1</td><td>6</td><td>0</td><td>1</td></tr>
-<tr><td><code>@jdsalasc/solvejs-date</code></td><td>1.3.0</td><td>13</td><td>0</td><td>1</td><td>3</td></tr>
-<tr><td><code>@jdsalasc/solvejs-list</code></td><td>1.3.0</td><td>10</td><td>0</td><td>0</td><td>2</td></tr>
-<tr><td><code>@jdsalasc/solvejs-numbers</code></td><td>1.3.0</td><td>12</td><td>0</td><td>0</td><td>2</td></tr>
-<tr><td><code>@jdsalasc/solvejs-objects</code></td><td>1.3.0</td><td>6</td><td>0</td><td>0</td><td>1</td></tr>
-<tr><td><code>@jdsalasc/solvejs-regex</code></td><td>1.3.0</td><td>4</td><td>1</td><td>1</td><td>2</td></tr>
-<tr><td><code>@jdsalasc/solvejs-string</code></td><td>1.3.0</td><td>8</td><td>0</td><td>0</td><td>2</td></tr>
-<tr><td><code>@jdsalasc/solvejs-validators</code></td><td>1.3.0</td><td>28</td><td>0</td><td>5</td><td>2</td></tr>
+              <tr><td><code>@jdsalasc/solvejs</code></td><td>1.4.0</td><td>0</td><td>0</td><td>0</td><td>1</td></tr>
+<tr><td><code>@jdsalasc/solvejs-constants</code></td><td>1.4.0</td><td>1</td><td>6</td><td>0</td><td>1</td></tr>
+<tr><td><code>@jdsalasc/solvejs-date</code></td><td>1.4.0</td><td>13</td><td>0</td><td>1</td><td>3</td></tr>
+<tr><td><code>@jdsalasc/solvejs-list</code></td><td>1.4.0</td><td>10</td><td>0</td><td>0</td><td>2</td></tr>
+<tr><td><code>@jdsalasc/solvejs-numbers</code></td><td>1.4.0</td><td>12</td><td>0</td><td>0</td><td>2</td></tr>
+<tr><td><code>@jdsalasc/solvejs-objects</code></td><td>1.4.0</td><td>6</td><td>0</td><td>0</td><td>1</td></tr>
+<tr><td><code>@jdsalasc/solvejs-regex</code></td><td>1.4.0</td><td>4</td><td>1</td><td>1</td><td>2</td></tr>
+<tr><td><code>@jdsalasc/solvejs-string</code></td><td>1.4.0</td><td>8</td><td>0</td><td>0</td><td>2</td></tr>
+<tr><td><code>@jdsalasc/solvejs-validators</code></td><td>1.4.0</td><td>28</td><td>0</td><td>5</td><td>2</td></tr>
             </tbody>
           </table>
         </div>

--- a/docs/guides/package-inventory.md
+++ b/docs/guides/package-inventory.md
@@ -4,15 +4,15 @@ Generated on 2026-02-07.
 
 | Package | Version | Functions | Consts | Types | Tests |
 |---|---:|---:|---:|---:|---:|
-| @jdsalasc/solvejs | 1.3.0 | 0 | 0 | 0 | 1 |
-| @jdsalasc/solvejs-constants | 1.3.0 | 1 | 6 | 0 | 1 |
-| @jdsalasc/solvejs-date | 1.3.0 | 13 | 0 | 1 | 3 |
-| @jdsalasc/solvejs-list | 1.3.0 | 10 | 0 | 0 | 2 |
-| @jdsalasc/solvejs-numbers | 1.3.0 | 12 | 0 | 0 | 2 |
-| @jdsalasc/solvejs-objects | 1.3.0 | 6 | 0 | 0 | 1 |
-| @jdsalasc/solvejs-regex | 1.3.0 | 4 | 1 | 1 | 2 |
-| @jdsalasc/solvejs-string | 1.3.0 | 8 | 0 | 0 | 2 |
-| @jdsalasc/solvejs-validators | 1.3.0 | 28 | 0 | 5 | 2 |
+| @jdsalasc/solvejs | 1.4.0 | 0 | 0 | 0 | 1 |
+| @jdsalasc/solvejs-constants | 1.4.0 | 1 | 6 | 0 | 1 |
+| @jdsalasc/solvejs-date | 1.4.0 | 13 | 0 | 1 | 3 |
+| @jdsalasc/solvejs-list | 1.4.0 | 10 | 0 | 0 | 2 |
+| @jdsalasc/solvejs-numbers | 1.4.0 | 12 | 0 | 0 | 2 |
+| @jdsalasc/solvejs-objects | 1.4.0 | 6 | 0 | 0 | 1 |
+| @jdsalasc/solvejs-regex | 1.4.0 | 4 | 1 | 1 | 2 |
+| @jdsalasc/solvejs-string | 1.4.0 | 8 | 0 | 0 | 2 |
+| @jdsalasc/solvejs-validators | 1.4.0 | 28 | 0 | 5 | 2 |
 
 ## Notes
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,6 +33,7 @@
             <li><a class="cookbook-link" href="./guides/nest-integration.html">Integrate SolveJS in NestJS</a></li>
             <li><a class="cookbook-link" href="./guides/validator-locale-matrix.html">Validator Locale Matrix</a></li>
             <li><a class="cookbook-link" href="./guides/package-inventory.html">Package Inventory</a></li>
+            <li><a class="cookbook-link" href="./guides/package-health-report.html">Package Health Report</a></li>
             <li><a class="cookbook-link" href="./guides/solvejs-vs-lodash.html">SolveJS vs Lodash</a></li>
             <li><a class="cookbook-link" href="./guides/solvejs-vs-datefns-validator.html">SolveJS vs date-fns + validator</a></li>
           </ul>


### PR DESCRIPTION
## Summary
- add package health report docs (md/html) with package status, issues, weak points, and next actions
- regenerate package inventory docs for current 1.4.0 snapshot
- add roadmap v1.5.0 candidate priorities in TODO
- add canonical npm description copy in NPM positioning guide
- harden release workflow with matrix publish, npm token guard, and idempotent version checks

## Validation
- npm run inventory
- npm run build
- npm test